### PR TITLE
フォント仕様の標準化

### DIFF
--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -33,9 +33,11 @@
   --color-syntax-number: #005cc5;
   
   /* Typography */
-  --font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
-  --font-family-mono: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-  --font-family-heading: var(--font-family-base);
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-mono: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
+  --font-family-base: var(--font-sans);
+  --font-family-mono: var(--font-mono);
+  --font-family-heading: var(--font-sans);
   
   /* Font Sizes - Responsive */
   --font-size-xs: 0.75rem;   /* 12px */


### PR DESCRIPTION
## 概要

ITDO書籍の統一フォント仕様に対応しました。

## 変更内容

- **CSS変数名の統一**: `--font-family-base` → `--font-sans`、`--font-family-mono` → `--font-mono`
- **フォントスタックの更新**: 標準仕様に準拠
- **絵文字フォントサポートを追加**: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"
- **クロスプラットフォーム対応**: "Helvetica Neue", "Monaco", "Menlo", "Ubuntu Mono", "source-code-pro"を追加

## 標準仕様

### Sans-serif
```css
--font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
```

### Monospace
```css
--font-mono: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "source-code-pro", monospace;
```

## 関連Issue

https://github.com/itdojp/it-engineer-knowledge-architecture/issues/19

## 効果

- ブランド一貫性の向上
- 読みやすさの改善
- クロスプラットフォーム対応の強化
- 絵文字表示の統一

🤖 Generated with [Claude Code](https://claude.ai/code)