### PR TITLE
chore: add CODEOWNERS (format/nav/CI)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS template for book repos (replace ownership handles as appropriate)
+
+# Bottom navigation include and related data
+docs/_includes/page-navigation.html   @itdojp/maintainers
+docs/_data/navigation.yml             @itdojp/maintainers
+
+# Jekyll config impacting layout/permalinks
+docs/_config.yml                      @itdojp/maintainers
+_config.yml                           @itdojp/maintainers
+
+# Nav/Pages link check workflow
+.github/workflows/nav-link-check.yml  @itdojp/maintainers
+


### PR DESCRIPTION
Add CODEOWNERS with placeholder @itdojp/maintainers for key files:\n- page-navigation include\n- navigation.yml\n- _config.yml\n- nav-link-check workflow\n\nPlease replace with the appropriate team/owners if needed.