### PR TITLE
docs: add bottom navigation to root

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,3 +40,4 @@ permalink: /
 ---
 
 Built with [Book Publishing Template v3.0](https://github.com/itdojp/book-publishing-template2)
+{% include page-navigation.html %}


### PR DESCRIPTION
Add bottom navigation include to docs/index.md so the root page shows prev/next/home controls.