### PR TITLE
docs: fix repository.github URL (absolute)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,7 +21,7 @@ defaults:
 
 # Repository information for edit links
 repository:
-  github: "itdojp/computational-physicalism-book"
+  github: "https://github.com/itdojp/computational-physicalism-book"
 
 exclude:
   - node_modules/


### PR DESCRIPTION
Set repository.github to https://github.com/itdojp/computational-physicalism-book so edit/view links are absolute (avoid Pages relative 404).