### PR TITLE
docs: ライセンス表記の整合

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ permalink: /
 📋 [詳細なライセンス条件](https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md)
 
 **お問い合わせ**  
-株式会社アイティードゥ（ITDO Inc.）  
+株式会社アイティードゥ (ITDO Inc.)  
 Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 
 ---


### PR DESCRIPTION
`docs/index.md` のライセンス表記が `LICENSE.md`（CC BY-NC-SA 4.0 / シリーズ統一ライセンス）と不整合だったため、表記を整合しました。

- 変更: `docs/index.md`
