### PR TITLE
Fix GitHubリンク生成のフォールバック

### DIFF
--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -47,7 +47,7 @@
 <body>
     {% assign repository_url = site.repository.github | default: site.repository %}
     {% if repository_url %}
-        {% unless repository_url contains 'http' %}
+        {% unless repository_url contains '://' %}
             {% assign repository_url = 'https://github.com/' | append: repository_url %}
         {% endunless %}
     {% endif %}

--- a/templates/layouts/book.html
+++ b/templates/layouts/book.html
@@ -44,7 +44,7 @@
 <body>
     {% assign repository_url = site.repository.github | default: site.repository %}
     {% if repository_url %}
-        {% unless repository_url contains 'http' %}
+        {% unless repository_url contains '://' %}
             {% assign repository_url = 'https://github.com/' | append: repository_url %}
         {% endunless %}
     {% endif %}


### PR DESCRIPTION
## 変更内容
- `site.repository.github` が未設定、または文字列（`owner/repo` や `https://github.com/...`）の場合でも GitHubリンク/編集リンクが有効になるように、`repository_url` をフォールバック＋URL正規化して利用します。

## 対象
- `docs/_layouts/book.html`
- `templates/layouts/book.html`
