### PR TITLE
Stage3: 表現・表記の微調整（第4章）

### DIFF
--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -289,7 +289,7 @@ class ValueAlignment:
 
 ## 5. 実装ロードマップ
 
-### 5.1 短期（1-3年）：基盤技術の確立
+### 5.1 短期（1〜3年）：基盤技術の確立
 
 ```python
 def short_term_milestones():
@@ -312,7 +312,7 @@ def short_term_milestones():
     }
 ```
 
-### 5.2 中期（3-10年）：人間レベルへの接近
+### 5.2 中期（3〜10年）：人間レベルへの接近
 
 ```python
 def medium_term_goals():
@@ -330,7 +330,7 @@ def medium_term_goals():
     }
 ```
 
-### 5.3 長期（10-30年）：共進化の実現
+### 5.3 長期（10〜30年）：共進化の実現
 
 ```python
 def long_term_vision():
@@ -427,7 +427,7 @@ computational_physicalism/
 
 **コミュニティ**：https://discord.gg/comp-physicalism
 
-**次のステップ**：
+**次のステップ**は次のとおりです。
 1. 理論の実装と検証
 2. ベンチマークの構築
 3. 実験結果の共有

--- a/src/chapters/chapter04/index.md
+++ b/src/chapters/chapter04/index.md
@@ -284,7 +284,7 @@ class ValueAlignment:
 
 ## 5. 実装ロードマップ
 
-### 5.1 短期（1-3年）：基盤技術の確立
+### 5.1 短期（1〜3年）：基盤技術の確立
 
 ```python
 def short_term_milestones():
@@ -307,7 +307,7 @@ def short_term_milestones():
     }
 ```
 
-### 5.2 中期（3-10年）：人間レベルへの接近
+### 5.2 中期（3〜10年）：人間レベルへの接近
 
 ```python
 def medium_term_goals():
@@ -325,7 +325,7 @@ def medium_term_goals():
     }
 ```
 
-### 5.3 長期（10-30年）：共進化の実現
+### 5.3 長期（10〜30年）：共進化の実現
 
 ```python
 def long_term_vision():
@@ -422,7 +422,7 @@ computational_physicalism/
 
 **コミュニティ**：https://discord.gg/comp-physicalism
 
-**次のステップ**：
+**次のステップ**は次のとおりです。
 1. 理論の実装と検証
 2. ベンチマークの構築
 3. 実験結果の共有


### PR DESCRIPTION
## 概要
Stage3（表現・スタイル）の小PRとして、第4章の表記を整合しました。

## 変更内容
- 数値レンジ表記を `-` → `〜` に統一（例: `1-3年`→`1〜3年`）
- 行末が「：」で終わるラベル行を、文として完結する表現に調整

## 対象
- `src/chapters/chapter04/index.md`
- `docs/chapters/chapter04/index.md`

## 補足
- 意味変更は行わず、表現・表記のみを調整しています。
