### PR TITLE
docs: README の導入文末尾を整形

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run preview
 
 ## GitHub Pages
 
-本書は GitHub Pages で公開されています：
+本書は GitHub Pages で公開されています。
 https://itdojp.github.io/computational-physicalism-book/
 
 ---


### PR DESCRIPTION
## 変更内容
- `README.md` の導入文で、文末がコロン（`：`）で終わる箇所を、文として完結する表現に整形しました。

## 目的
- GitHubリポジトリの入口（README）を、初心者が読み進めやすい句読点・文体に揃えます（Stage3: 表現・スタイル）。

## 影響範囲
- 表現のみ（意味は変更していません）。
