### PR TITLE
[codex] Add computational physicalism metadata gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -33,6 +33,9 @@ jobs:
           cache: npm
           cache-dependency-path: book-formatter/package-lock.json
 
+      - name: Check repository metadata
+        run: node scripts/check-metadata-consistency.js
+
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ npm run build
 npm run preview
 ```
 
+## ローカル品質チェック
+
+```bash
+# package / Jekyll / 公開ページ metadata の整合性を確認
+npm run check:metadata
+```
+
 ## GitHub Pages
 
 本書は GitHub Pages で公開されています。

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 title: "計算論的物理主義"
 description: "計算可能性理論と物理的制約の観点から、人間とAIの知能の等価性を探求する哲学的・技術的論考"
 author: "太田和彦（株式会社アイティードゥ）"
+version: "1.0.0"
 baseurl: "/computational-physicalism-book"
 url: "https://itdojp.github.io"
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
 title: "計算論的物理主義"
 description: "計算可能性理論と物理的制約の観点から、人間とAIの知能の等価性を探求する哲学的・技術的論考"
 author: "太田和彦（株式会社アイティードゥ）"
+version: "1.0.0"
 baseurl: "/computational-physicalism-book"
 url: "https://itdojp.github.io"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "book-publishing-template-improved",
-  "version": "2.0.0",
+  "name": "computational-physicalism-book",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "book-publishing-template-improved",
-      "version": "2.0.0",
+      "name": "computational-physicalism-book",
+      "version": "1.0.0",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "fs-extra": "^11.3.0",
@@ -1678,9 +1678,9 @@
       "optional": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/package-simple.json
+++ b/package-simple.json
@@ -1,8 +1,8 @@
 {
-  "name": "book-publishing-template-improved",
-  "version": "2.0.0",
-  "description": "Improved Book Publishing Template with Easy Setup",
-  "author": "Book Publishing Template Contributors",
+  "name": "computational-physicalism-book",
+  "version": "1.0.0",
+  "description": "計算可能性理論と物理的制約の観点から、人間とAIの知能の等価性を探求する哲学的・技術的論考",
+  "author": "太田和彦（株式会社アイティードゥ）",
   "license": "CC-BY-NC-SA-4.0",
   "engines": {
     "node": ">=20.0.0"
@@ -10,6 +10,7 @@
   "scripts": {
     "setup": "node easy-setup.js",
     "build": "node scripts/build-simple.js",
+    "check:metadata": "node scripts/check-metadata-consistency.js",
     "build:full": "node scripts/build.js",
     "preview": "npm run build && npx http-server docs -p 8080 --silent",
     "clean": "rm -rf docs output temp",
@@ -39,10 +40,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/itdojp/book-publishing-template.git"
+    "url": "git+https://github.com/itdojp/computational-physicalism-book.git"
   },
   "bugs": {
-    "url": "https://github.com/itdojp/book-publishing-template/issues"
+    "url": "https://github.com/itdojp/computational-physicalism-book/issues"
   },
-  "homepage": "https://github.com/itdojp/book-publishing-template#readme"
+  "homepage": "https://itdojp.github.io/computational-physicalism-book/"
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "computational-physicalism-book",
   "version": "1.0.0",
-  "description": "Computational Physicalism: A Theory of Human-AI Intelligence Equivalence",
-  "author": "書籍著者",
+  "description": "計算可能性理論と物理的制約の観点から、人間とAIの知能の等価性を探求する哲学的・技術的論考",
+  "author": "太田和彦（株式会社アイティードゥ）",
   "license": "CC-BY-NC-SA-4.0",
   "engines": {
     "node": ">=20.0.0"
@@ -10,6 +10,7 @@
   "scripts": {
     "setup": "node easy-setup.js",
     "build": "node scripts/build-simple.js",
+    "check:metadata": "node scripts/check-metadata-consistency.js",
     "build:full": "node scripts/build.js",
     "preview": "npm run build && npx http-server public -p 8080 --silent",
     "deploy": "bash scripts/deploy.sh",
@@ -46,5 +47,5 @@
   "bugs": {
     "url": "https://github.com/itdojp/computational-physicalism-book/issues"
   },
-  "homepage": "https://github.com/itdojp/computational-physicalism-book#readme"
+  "homepage": "https://itdojp.github.io/computational-physicalism-book/"
 }

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const root = process.cwd();
+const errors = [];
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(root, file), 'utf8'));
+  } catch (error) {
+    errors.push(`${file}: JSONを読み込めません: ${error.message}`);
+    return null;
+  }
+}
+
+function readText(file) {
+  try {
+    return fs.readFileSync(path.join(root, file), 'utf8');
+  } catch (error) {
+    errors.push(`${file}: ファイルを読み込めません: ${error.message}`);
+    return '';
+  }
+}
+
+function parseSimpleYaml(text) {
+  const data = {};
+  const lines = text.split(/\r?\n/);
+  let currentKey = null;
+
+  for (const line of lines) {
+    if (!line.trim() || line.trimStart().startsWith('#')) {
+      continue;
+    }
+
+    const nestedMatch = line.match(/^\s{2}([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (nestedMatch && currentKey) {
+      if (!data[currentKey] || typeof data[currentKey] !== 'object') {
+        data[currentKey] = {};
+      }
+      data[currentKey][nestedMatch[1]] = stripYamlScalar(nestedMatch[2]);
+      continue;
+    }
+
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    currentKey = match[1];
+    const value = match[2];
+    data[currentKey] = value === '' ? {} : stripYamlScalar(value);
+  }
+
+  return data;
+}
+
+function stripYamlScalar(value) {
+  return String(value).trim().replace(/^['"]|['"]$/g, '');
+}
+
+function parseFrontMatter(file) {
+  const text = readText(file);
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) {
+    errors.push(`${file}: front matterが見つかりません`);
+    return {};
+  }
+  return parseSimpleYaml(match[1]);
+}
+
+function repoInfoFromUrl(url) {
+  const normalized = String(url || '').replace(/^git\+/, '').replace(/\/$/, '');
+  const match = normalized.match(/github\.com[:/]([^/]+)\/([^/]+)$/);
+  if (!match) {
+    errors.push(`book-config.json: repository.urlからowner/repoを抽出できません: ${url}`);
+    return { owner: '', name: '' };
+  }
+  return {
+    owner: match[1],
+    name: match[2].replace(/\.git$/, ''),
+  };
+}
+
+function expectEqual(label, actual, expected) {
+  if (actual !== expected) {
+    errors.push(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectPackage(file, pkg, expected) {
+  if (!pkg) return;
+  expectEqual(`${file}.name`, pkg.name, expected.name);
+  expectEqual(`${file}.version`, pkg.version, expected.version);
+  expectEqual(`${file}.description`, pkg.description, expected.description);
+  expectEqual(`${file}.author`, pkg.author, expected.author);
+  expectEqual(`${file}.license`, pkg.license, expected.license);
+  expectEqual(`${file}.homepage`, pkg.homepage, expected.homepage);
+  expectEqual(`${file}.repository.type`, pkg.repository && pkg.repository.type, 'git');
+  expectEqual(`${file}.repository.url`, pkg.repository && pkg.repository.url, expected.repositoryUrl);
+  expectEqual(`${file}.bugs.url`, pkg.bugs && pkg.bugs.url, expected.bugsUrl);
+  expectEqual(`${file}.scripts.check:metadata`, pkg.scripts && pkg.scripts['check:metadata'], 'node scripts/check-metadata-consistency.js');
+}
+
+const bookConfig = readJson('book-config.json');
+const pkg = readJson('package.json');
+const simplePkg = readJson('package-simple.json');
+const lock = readJson('package-lock.json');
+const rootConfig = parseSimpleYaml(readText('_config.yml'));
+const docsConfig = parseSimpleYaml(readText('docs/_config.yml'));
+const indexFrontMatter = parseFrontMatter('docs/index.md');
+
+if (bookConfig && pkg) {
+  const book = bookConfig.book || {};
+  const repo = repoInfoFromUrl(book.repository && book.repository.url);
+  const pagesUrl = (bookConfig.deployment && bookConfig.deployment.siteUrl) || '';
+  let pageUrl;
+  try {
+    pageUrl = new URL(pagesUrl);
+  } catch (error) {
+    errors.push(`book-config.json: deployment.siteUrlがURLとして解釈できません: ${pagesUrl}`);
+    pageUrl = new URL('https://example.invalid/');
+  }
+  const baseurl = pageUrl.pathname.replace(/\/$/, '');
+  const expected = {
+    name: repo.name,
+    version: pkg.version,
+    description: book.description,
+    author: book.author && book.author.name,
+    license: 'CC-BY-NC-SA-4.0',
+    homepage: pagesUrl,
+    repositoryUrl: `git+https://github.com/${repo.owner}/${repo.name}.git`,
+    bugsUrl: `https://github.com/${repo.owner}/${repo.name}/issues`,
+  };
+
+  expectPackage('package.json', pkg, expected);
+  expectPackage('package-simple.json', simplePkg, expected);
+
+  if (lock) {
+    expectEqual('package-lock.json.name', lock.name, expected.name);
+    expectEqual('package-lock.json.version', lock.version, expected.version);
+    expectEqual('package-lock.json.packages[""].name', lock.packages && lock.packages[''] && lock.packages[''].name, expected.name);
+    expectEqual('package-lock.json.packages[""].version', lock.packages && lock.packages[''] && lock.packages[''].version, expected.version);
+    expectEqual('package-lock.json.packages[""].license', lock.packages && lock.packages[''] && lock.packages[''].license, expected.license);
+  }
+
+  for (const [file, cfg] of [['_config.yml', rootConfig], ['docs/_config.yml', docsConfig]]) {
+    expectEqual(`${file}.title`, cfg.title, book.title);
+    expectEqual(`${file}.description`, cfg.description, book.description);
+    expectEqual(`${file}.author`, cfg.author, expected.author);
+    expectEqual(`${file}.version`, cfg.version, expected.version);
+    expectEqual(`${file}.baseurl`, cfg.baseurl, baseurl);
+    expectEqual(`${file}.url`, cfg.url, pageUrl.origin);
+    expectEqual(`${file}.repository.github`, cfg.repository && cfg.repository.github, `${repo.owner}/${repo.name}`);
+  }
+
+  expectEqual('docs/index.md.version', indexFrontMatter.version, expected.version);
+  expectEqual('docs/index.md.title', indexFrontMatter.title, book.title);
+}
+
+if (errors.length) {
+  console.error('Metadata consistency check failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('Metadata consistency check passed.');


### PR DESCRIPTION
## 概要

- `package.json` / `package-simple.json` / `package-lock.json` の template由来 metadata drift を `computational-physicalism-book` の実リポジトリ情報に合わせました。
- root / docs の Jekyll config に book version metadata を追加しました。
- `scripts/check-metadata-consistency.js` を追加し、package / lockfile / Jekyll config / `docs/index.md` / Pages URL の整合性を検出できるようにしました。
- Book QA workflow に repository metadata check を追加し、`js-yaml` production transitive dependency を audit clean な `3.14.2` に更新しました。

Refs: itdojp/it-engineer-knowledge-architecture#152

## 背景 / 判断

- #152 quality sprint の次対象として、本リポジトリの open Issue / open PR を確認しました。
- open Issue / open PR はありませんでした。
- 変更前は `package-simple.json` と `package-lock.json` が `book-publishing-template-improved` / `book-publishing-template` のままで、`package.json` の author / description / homepage も公開サイト metadata とずれていました。
- `npm audit --omit=dev --omit=optional` で production/non-optional 側の `js-yaml <3.14.2` advisory が検出されました。
- 本PRは本文リライトではなく、公開/パッケージ/CI metadata の軽微な整合と再発防止に限定しています。既存 `src/**/*.md` の markdownlint debt により `npm run test:light` が失敗する点は別スライス候補として残しています。

## QA

- [x] `PUPPETEER_SKIP_DOWNLOAD=true npm ci`
  - 既存 dev / optional dependency audit findings は残存
- [x] `node scripts/check-metadata-consistency.js`
- [x] `npm run check:metadata`
- [x] `npm audit --omit=dev --omit=optional`（0 vulnerabilities）
- [x] `git diff --check`
- [x] `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-computational-physicalism-book bundle install`（`docs/`内）
- [x] `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-computational-physicalism-book bundle exec jekyll build --source . --destination _site --baseurl "/computational-physicalism-book"`（`docs/`内）
- [x] built-site smoke（top / introduction / chapter 04 markers）
- [x] Book QA equivalent with `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`
  - Unicode（fail-on warn）
  - textlint / PRH（fail-on error）
  - internal links / anchors
  - layout risk（fail-on error）
  - markdown structure（fail-on error）

## Review Completion Gate

- [x] GitHub Copilot review を依頼した
- [x] review 本文・inline comment・suggestion を全件確認した
- [x] 修正が必要な指摘は対応し、不要な指摘は理由を返信した
- [x] 未解決 review thread が 0 件であることを確認した

## Pages確認

- 確認URL: https://itdojp.github.io/computational-physicalism-book/
- [x] merge 後に main CI / Pages 反映を確認する