### PR TITLE
[codex] Add audit gate for computational physicalism QA

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Install repository dependencies
         run: npm ci --omit=optional
 
-      - name: Run local metadata and lint QA
-        run: npm run check:metadata && npm run lint:light
+      - name: Run local metadata, security, and lint QA
+        run: npm run check:metadata && npm run check:security && npm run lint:light
 
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - 「証明」「必然」「完全」「唯一」「実現済み」といった表現は、数学的定理、工学的検証、編集上の立場のどれを指すか明示する。
 - 意識、クオリア、自由意志、価値判断については、反対説や未解決論点を射程外として隠さず、読者が実証済み結論と誤読しないようにする。
 - AI規制、標準、モデル能力、電力制約など時点依存の話題は、確認日と出典を PR body に記録する。
-- GitHub Copilot review の本文、inline comment、suggestion を全件確認し、未解決 review thread が 0 件であることを完了条件にする。
+- `GitHub Copilot review` の本文、`inline comment`、`suggestion` を全件確認し、未解決 `review thread` が 0 件であることを完了条件にする。
 
 ## 内容
 
@@ -44,9 +44,15 @@ npm run preview
 # package / Jekyll / 公開ページ metadata の整合性を確認
 npm run check:metadata
 
+# optional 依存を除いた audit findings を確認
+npm run check:security
+
 # Markdown lint と簡易ビルドを確認
 npm run test:light
+
 ```
+
+注: CI の Node 20 互換を維持するため `markdownlint-cli` は 0.48 系のまま使い、audit findings は `gray-matter` / `markdownlint-cli` 配下に限定した `overrides` で解消しています。
 
 ## GitHub Pages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -596,15 +596,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -1226,6 +1217,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
+      "optional": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1499,6 +1491,34 @@
       },
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/has-flag": {
@@ -1804,19 +1824,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
@@ -1934,15 +1941,25 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -2017,10 +2034,20 @@
       "license": "Python-2.0"
     },
     "node_modules/markdownlint-cli/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3304,12 +3331,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/streamx": {
       "version": "2.22.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "configure:workflows": "node scripts/configure-workflows.js",
     "lint:light": "markdownlint 'src/**/*.md' --ignore node_modules",
     "test:light": "npm run lint:light && npm run build",
-    "help": "echo 'Available commands:\n  npm run setup - Interactive setup\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run configure:workflows - Disable problematic workflows\n  npm run deploy - Deploy to GitHub Pages'"
+    "help": "echo 'Available commands:\n  npm run setup - Interactive setup\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run configure:workflows - Disable problematic workflows\n  npm run deploy - Deploy to GitHub Pages'",
+    "check:security": "npm audit --omit=optional"
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
@@ -47,5 +48,17 @@
   "bugs": {
     "url": "https://github.com/itdojp/computational-physicalism-book/issues"
   },
-  "homepage": "https://itdojp.github.io/computational-physicalism-book/"
+  "homepage": "https://itdojp.github.io/computational-physicalism-book/",
+  "overrides": {
+    "gray-matter": {
+      "js-yaml": "4.3.0"
+    },
+    "markdownlint-cli": {
+      "js-yaml": "4.3.0",
+      "markdown-it": {
+        ".": "14.2.0",
+        "linkify-it": "5.0.1"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add an explicit `npm run check:security` gate and wire it into Book QA.
- Use scoped npm `overrides` for `gray-matter` and `markdownlint-cli` transitive audit findings while keeping the Node 20-compatible `markdownlint-cli` 0.48 line.
- Document the local security check and review-completeness gate terminology in README.

## Validation
- `npm ci --omit=optional`
- `npm run check:metadata`
- `npm run check:security` (0 vulnerabilities)
- `npm run lint:light`
- pinned book-formatter checks on `docs`: unicode, textlint, links, layout risk, markdown structure
- `bundle exec jekyll build --destination _site` from `docs/` with GitHub Pages gem set, plus built-site smoke for the top page marker
- `npm ls js-yaml markdown-it linkify-it --omit=optional`
- `git diff --check`

Refs: itdojp/it-engineer-knowledge-architecture#170
