### PR TITLE
fix: update brace-expansion advisory patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- update the transitive dev dependency `brace-expansion` from `5.0.6` to `5.0.7`
- clear `GHSA-3jxr-9vmj-r5cp` without changing manifests, book content, or build contracts
- keep the dependency fix separate from the claim-class work in #157

## Verification

- `npm ci --omit=optional`
- `npm ls brace-expansion --all` → `brace-expansion@5.0.7`
- `npm audit --omit=optional` → 0 vulnerabilities
- `npm run check:metadata`
- `npm run lint:light`
- `npm run check:build-determinism`
- pinned `book-formatter@69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c`: Unicode/Textlint/links/layout/structure all 0 issues

Closes #160
